### PR TITLE
Fix/out of bound candidates

### DIFF
--- a/src/refinedoc/refined_document.py
+++ b/src/refinedoc/refined_document.py
@@ -124,9 +124,14 @@ class RefinedDocument:
                     * positional_weights[line_index]
                 )
             except IndexError as e:
-                logger.info("")
-                score = positional_weights[line_index]
-            if score >= 0.5:
+                if line_index >= len(positional_weights):
+                    logger.warning(
+                        f"Line index {line_index} is out of bounds for positional weights of length {len(positional_weights)}"
+                    )
+                    score = 0
+                else:
+                    score = positional_weights[line_index]
+            if candidate and score >= 0.5:
                 detected.append(candidate)
         return detected
 

--- a/tests/test_refined_document.py
+++ b/tests/test_refined_document.py
@@ -232,7 +232,7 @@ class TestRefinedDocument(TestCase):
         self.assertListEqual(f_dr, f_ref)
         self.assertListEqual(b_dr, b_ref)
 
-    def test_vrious_qty_lines(self):
+    def test_various_qty_lines(self):
         document = [
             [
                 "header 1",

--- a/tests/test_refined_document.py
+++ b/tests/test_refined_document.py
@@ -292,3 +292,64 @@ class TestRefinedDocument(TestCase):
         self.assertListEqual(h_dr, h_ref)
         self.assertListEqual(f_dr, f_ref)
         self.assertListEqual(b_dr, b_ref)
+
+    def test_vrious_qty_lines2(self):
+        document = [
+            [
+                "lorem ipsum dolor sit amet",
+            ],
+            [
+                "header 2",
+                "subheader 2",
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                "footer 2",
+            ],
+            [
+                "ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
+            ],
+            [
+                "duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
+            ],
+        ]
+
+        rd = RefinedDocument(content=document)
+
+        h_dr = rd.headers
+        f_dr = rd.footers
+        b_dr = rd.body
+
+        h_ref = [
+            [],
+            [],
+            [],
+            [],
+        ]
+
+        f_ref = [
+            [],
+            [],
+            [],
+            [],
+        ]
+
+        b_ref = [
+            [
+                "lorem ipsum dolor sit amet",
+            ],
+            [
+                "header 2",
+                "subheader 2",
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                "footer 2",
+            ],
+            [
+                "ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat"
+            ],
+            [
+                "duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur"
+            ],
+        ]
+
+        self.assertListEqual(h_dr, h_ref)
+        self.assertListEqual(f_dr, f_ref)
+        self.assertListEqual(b_dr, b_ref)

--- a/tests/test_refined_document.py
+++ b/tests/test_refined_document.py
@@ -293,7 +293,7 @@ class TestRefinedDocument(TestCase):
         self.assertListEqual(f_dr, f_ref)
         self.assertListEqual(b_dr, b_ref)
 
-    def test_vrious_qty_lines2(self):
+    def test_various_qty_lines2(self):
         document = [
             [
                 "lorem ipsum dolor sit amet",

--- a/tests/test_refined_document.py
+++ b/tests/test_refined_document.py
@@ -231,3 +231,64 @@ class TestRefinedDocument(TestCase):
         self.assertListEqual(h_dr, h_ref)
         self.assertListEqual(f_dr, f_ref)
         self.assertListEqual(b_dr, b_ref)
+
+    def test_vrious_qty_lines(self):
+        document = [
+            [
+                "header 1",
+                "subheader 1",
+                "lorem ipsum dolor sit amet",
+                "consectetur adipiscing elit",
+                "footer 1",
+            ],
+            [
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+            ],
+            [
+                "ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
+            ],
+            [
+                "duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
+            ],
+        ]
+
+        rd = RefinedDocument(content=document)
+
+        h_dr = rd.headers
+        f_dr = rd.footers
+        b_dr = rd.body
+
+        h_ref = [
+            [],
+            [],
+            [],
+            [],
+        ]
+
+        f_ref = [
+            [],
+            [],
+            [],
+            [],
+        ]
+
+        b_ref = [
+            [
+                "header 1",
+                "subheader 1",
+                "lorem ipsum dolor sit amet",
+                "consectetur adipiscing elit",
+                "footer 1",
+            ],
+            ["sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"],
+            [
+                "ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat"
+            ],
+            [
+                "duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur"
+            ],
+        ]
+
+        self.assertListEqual(h_dr, h_ref)
+        self.assertListEqual(f_dr, f_ref)
+        self.assertListEqual(b_dr, b_ref)


### PR DESCRIPTION
This pull request improves error handling in the `_detect_similar_lines` method and adds new test cases to the `tests/test_refined_document.py` file to ensure the robustness of the `RefinedDocument` class. Below are the key changes:

### Error Handling Improvements:
* Enhanced `_detect_similar_lines` in `src/refinedoc/refined_document.py` to handle cases where `line_index` is out of bounds for the `positional_weights` list. A warning is logged, and a default score of `0` is assigned in such cases. Additionally, the `if` condition was updated to check if `candidate` is truthy before appending it to `detected`.

### Test Coverage Enhancements:
* Added two new test cases, `test_vrious_qty_lines` and `test_vrious_qty_lines2`, in `tests/test_refined_document.py` to validate the behavior of the `RefinedDocument` class with various document structures. These tests ensure that headers, footers, and body content are correctly identified and separated.