### PR TITLE
Feature/roman numeral support

### DIFF
--- a/src/refinedoc/helpers.py
+++ b/src/refinedoc/helpers.py
@@ -1,3 +1,4 @@
+import re
 from typing import Generator
 
 
@@ -33,3 +34,28 @@ def generate_weights(weight_len: int = 5) -> Generator:
         yield 0.75
     for _ in range(max(0, weight_len - 2)):
         yield 0.5
+
+
+def neutralize_arabic_numerals(input_str: str, neutral_representation: str = "@"):
+    """
+    Replace Arabic numerals in a string with neutral representation.
+    :param input_str: the input string containing Arabic numerals
+    :param neutral_representation: the character to replace Arabic numerals with (e.g., '@')
+    :return: a string with Arabic numerals replaced by a neutral representation
+    """
+    digits = "0123456789"
+    map_trans = str.maketrans(digits, neutral_representation * len(digits))
+    ret = input_str.translate(map_trans)
+    return ret
+
+
+def neutralize_roman_numerals(input_str: str, neutral_representation: str = "@"):
+    """
+    Replace Roman numerals in a string with neutral representation.
+    :param input_str: the input string containing Roman numerals
+    :param neutral_representation: the character to replace Roman numerals with (e.g., '@')
+    :return: a string with Roman numerals replaced by a neutral representation
+    """
+    regex = r"\b[IVXLCDM]{1,4}\b(?![A-Z])"
+    ret = re.sub(regex, neutral_representation, input_str, flags=re.IGNORECASE)
+    return ret

--- a/src/refinedoc/refined_document.py
+++ b/src/refinedoc/refined_document.py
@@ -4,7 +4,11 @@ from difflib import SequenceMatcher
 from statistics import mean
 
 from refinedoc.enumeration import TargetedPart
-from refinedoc.helpers import generate_weights, unify_list_len
+from refinedoc.helpers import (
+    generate_weights,
+    neutralize_arabic_numerals,
+    unify_list_len,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,11 +82,8 @@ class RefinedDocument:
     def _compare(self, from_compare: str, to_compare_candidate: str):
 
         # Handle page number by replacing it
-        digits = "0123456789"
-        map_trans = str.maketrans(digits, "@" * len(digits))
-
-        from_compare = from_compare.translate(map_trans).lower()
-        to_compare_candidate = to_compare_candidate.translate(map_trans).lower()
+        from_compare = neutralize_arabic_numerals(from_compare).lower()
+        to_compare_candidate = neutralize_arabic_numerals(to_compare_candidate).lower()
         s = SequenceMatcher(None, from_compare, to_compare_candidate)
 
         if self.ratio_speed == 1:

--- a/src/refinedoc/refined_document.py
+++ b/src/refinedoc/refined_document.py
@@ -7,6 +7,7 @@ from refinedoc.enumeration import TargetedPart
 from refinedoc.helpers import (
     generate_weights,
     neutralize_arabic_numerals,
+    neutralize_roman_numerals,
     unify_list_len,
 )
 
@@ -80,10 +81,13 @@ class RefinedDocument:
             self._separate_header_footer(TargetedPart.FOOTER)
 
     def _compare(self, from_compare: str, to_compare_candidate: str):
-
         # Handle page number by replacing it
-        from_compare = neutralize_arabic_numerals(from_compare).lower()
-        to_compare_candidate = neutralize_arabic_numerals(to_compare_candidate).lower()
+        from_compare = neutralize_roman_numerals(
+            neutralize_arabic_numerals(from_compare)
+        ).lower()
+        to_compare_candidate = neutralize_roman_numerals(
+            neutralize_arabic_numerals(to_compare_candidate)
+        ).lower()
         s = SequenceMatcher(None, from_compare, to_compare_candidate)
 
         if self.ratio_speed == 1:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+
+from refinedoc.helpers import (
+    generate_weights,
+    neutralize_arabic_numerals,
+    neutralize_roman_numerals,
+    unify_list_len,
+)
+
+
+class Test(TestCase):
+    def test_unify_list_len(self):
+        to_len_unified = [["a", "b", "c"], ["d", "e"], ["f"]]
+        unify_list_len(to_len_unified)
+        self.assertEqual(
+            to_len_unified, [["a", "b", "c"], ["d", "e", ""], ["f", "", ""]]
+        )
+
+        to_len_unified = [["a", "b", "c"], ["d", "e"], ["f"]]
+        unify_list_len(to_len_unified, at_top=True)
+        self.assertEqual(
+            to_len_unified, [["a", "b", "c"], ["", "d", "e"], ["", "", "f"]]
+        )
+
+    def test_generate_weights(self):
+        weights = list(generate_weights(5))
+        self.assertEqual(weights, [1.0, 0.75, 0.5, 0.5, 0.5])
+
+        weights = list(generate_weights(2))
+        self.assertEqual(weights, [1.0, 0.75])
+
+        weights = list(generate_weights(1))
+        self.assertEqual(weights, [1.0])
+
+        weights = list(generate_weights(0))
+        self.assertEqual(weights, [None])
+
+    def test_neutralize_arabic_numerals(self):
+        self.assertEqual(neutralize_arabic_numerals("abc 1234"), "abc @@@@")
+        self.assertEqual(
+            neutralize_arabic_numerals("abc 1234", neutral_representation="*"),
+            "abc ****",
+        )
+
+        self.assertEqual(neutralize_arabic_numerals("abc 1 2 3 4"), "abc @ @ @ @")
+
+    def test_neutralize_roman_numerals(self):
+        self.assertEqual(neutralize_roman_numerals("BMC IV"), "BMC @")
+        self.assertEqual(neutralize_roman_numerals("abc iv"), "abc @")
+        self.assertEqual(neutralize_roman_numerals("abc iV"), "abc @")
+        self.assertEqual(neutralize_roman_numerals("vrai i v"), "vrai @ @")
+
+        self.assertEqual(
+            neutralize_roman_numerals("abc IV", neutral_representation="*"), "abc *"
+        )
+        self.assertEqual(
+            neutralize_roman_numerals("abc i v", neutral_representation="*"),
+            "abc * *",
+        )

--- a/tests/test_refined_document.py
+++ b/tests/test_refined_document.py
@@ -116,6 +116,57 @@ class TestRefinedDocument(TestCase):
             if i in pages_with_subheader:
                 self.assertEqual(f"subheader {i}", header[-1])
 
+    def test_header_roman_numerals(self):
+        page0 = ["header 0", " lorem ipsum dolor sit amet"]
+        page1 = ["header I", " consectetur adipiscing elit"]
+        page2 = [
+            "header II",
+            "subheader II",
+            "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+        ]
+        page3 = [
+            "header III",
+            "subheader III",
+            "ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
+        ]
+        page4 = [
+            "header IV",
+            "subheader IV",
+            "duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
+        ]
+        page5 = [
+            "",
+            "subheader V",
+            "excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum",
+        ]
+        page6 = [
+            "header VI",
+            "subheader VI",
+            "sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium",
+        ]
+        content = [
+            page0,
+            page1,
+            page2,
+            page3,
+            page4,
+            page5,
+            page6,
+        ]
+        rd = RefinedDocument(content=content)
+        headers = rd.headers
+
+        for i, header in enumerate(headers):
+            if i == 2:
+                self.assertEqual("header II", header[0])
+
+            if i == 3:
+                self.assertEqual("header III", header[0])
+            if i == 4:
+                self.assertEqual("header IV", header[0])
+            if i == 6:
+                self.assertEqual("header VI", header[0])
+
     def test_separate_footer(self):
         page0 = ["lorem ipsum dolor sit amet", "conescturs", "", "footer 0"]
         page1 = ["consectetur adipiscing elit", "blablabla", "", "footer 1"]


### PR DESCRIPTION
Partialy from this issue : #4 

This pull request introduces new helper functions for neutralizing Arabic and Roman numerals, integrates these functions into the document refinement process, and adds corresponding unit tests to ensure functionality. These changes aim to improve the accuracy and maintainability of text comparisons in the `refinedoc` module.

### New helper functions:
* Added `neutralize_arabic_numerals` to replace Arabic numerals in a string with a neutral representation, and `neutralize_roman_numerals` to replace Roman numerals with a neutral representation (`src/refinedoc/helpers.py`).

### Integration into document refinement:
* Updated `_compare` method in `RefinedDocument` to use the new numeral-neutralizing functions, replacing the previous implementation for handling Arabic numerals (`src/refinedoc/refined_document.py`).

### Test coverage:
* Added unit tests for `neutralize_arabic_numerals` and `neutralize_roman_numerals` to validate their behavior with various inputs (`tests/test_helpers.py`).
* Introduced a new test case in `test_refined_document.py` to verify proper handling of Roman numerals in document headers (`tests/test_refined_document.py`).