### PR TITLE
Fix/no candidates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "refinedoc"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Théo NARDIN", email="theo.nardin@learningplanetinstitute.org" },
 ]

--- a/src/refinedoc/refined_document.py
+++ b/src/refinedoc/refined_document.py
@@ -43,8 +43,16 @@ class RefinedDocument:
             raise ValueError(f"Speed must be between 1 and 3: {ratio_speed}")
 
         self._processed_body: list[list[str]] = content  # Initialize body field
-        self._processed_headers: list[list[str]] | None = None
-        self._processed_footers: list[list[str]] | None = None
+
+        if len(content) == 1:
+            logger.warning(
+                "The content provided is empty. Headers and footers will be set to empty lists."
+            )
+            self._processed_headers = [[]]
+            self._processed_footers = [[]]
+        else:
+            self._processed_headers: list[list[str]] | None = None
+            self._processed_footers: list[list[str]] | None = None
 
         self.win = win
 

--- a/src/refinedoc/refined_document.py
+++ b/src/refinedoc/refined_document.py
@@ -44,9 +44,7 @@ class RefinedDocument:
 
         self._processed_body: list[list[str]] = content  # Initialize body field
 
-        if len(content) == 1:
-            logger.warning(
-                "The content provided is empty. Headers and footers will be set to empty lists."
+                "The content provided has only one page. Headers and footers will be set to empty lists."
             )
             self._processed_headers = [[]]
             self._processed_footers = [[]]

--- a/tests/test_refined_document.py
+++ b/tests/test_refined_document.py
@@ -404,3 +404,57 @@ class TestRefinedDocument(TestCase):
         self.assertListEqual(h_dr, h_ref)
         self.assertListEqual(f_dr, f_ref)
         self.assertListEqual(b_dr, b_ref)
+
+    def test_empty_document(self):
+        document = []
+
+        rd = RefinedDocument(content=document)
+
+        h_dr = rd.headers
+        f_dr = rd.footers
+        b_dr = rd.body
+
+        h_ref = []
+
+        f_ref = []
+
+        b_ref = []
+
+        self.assertListEqual(h_dr, h_ref)
+        self.assertListEqual(f_dr, f_ref)
+        self.assertListEqual(b_dr, b_ref)
+
+    def test_single_page_document(self):
+        document = [
+            [
+                "header 1",
+                "subheader 1",
+                "lorem ipsum dolor sit amet",
+                "consectetur adipiscing elit",
+                "footer 1",
+            ]
+        ]
+
+        rd = RefinedDocument(content=document)
+
+        h_dr = rd.headers
+        f_dr = rd.footers
+        b_dr = rd.body
+
+        h_ref = [[]]
+
+        f_ref = [[]]
+
+        b_ref = [
+            [
+                "header 1",
+                "subheader 1",
+                "lorem ipsum dolor sit amet",
+                "consectetur adipiscing elit",
+                "footer 1",
+            ]
+        ]
+
+        self.assertListEqual(h_dr, h_ref)
+        self.assertListEqual(f_dr, f_ref)
+        self.assertListEqual(b_dr, b_ref)


### PR DESCRIPTION
This pull request improves the handling of empty and single-page documents in the `RefinedDocument` class, ensuring that headers and footers are set to empty lists in these cases. It also adds corresponding tests to verify this behavior. Additionally, the package version is bumped to reflect these changes.

**Improvements to document handling:**

* Updated the `RefinedDocument` class to set `_processed_headers` and `_processed_footers` to `[[]]` and log a warning when the provided content has only one page, ensuring consistent behavior for empty and single-page documents.

**Testing enhancements:**

* Added `test_empty_document` and `test_single_page_document` to verify that headers and footers are empty lists and the body is handled correctly for empty and single-page documents.

**Versioning:**

* Bumped the package version from `1.0.0` to `1.0.1` in `pyproject.toml` to reflect these updates.